### PR TITLE
fix: this.$root.$mp.query bug

### DIFF
--- a/src/platforms/mp/runtime/instance/index.js
+++ b/src/platforms/mp/runtime/instance/index.js
@@ -7,10 +7,10 @@ export * from './render-helpers/render-slot'
 export * from './render-helpers/render-if'
 export * from './render-helpers/render-list'
 
-export function initRootVM (mpVM, opt = {}) {
+export function initRootVM (mpVM, opt = {}, query) {
   const { options, Component, platform } = opt
   const { mpType } = options
-  const mpVMOptions = mpVM && mpVM.options || {}
+  const mpVMOptions = query || {}
   const { update, instantUpdate } = createUpdateFn(mpVM)
   const $mp = {
     platform,

--- a/src/platforms/mp/runtime/lifecycle/app.js
+++ b/src/platforms/mp/runtime/lifecycle/app.js
@@ -20,7 +20,7 @@ app.init = function (opt) {
     },
     //	Function	生命周期函数--监听小程序初始化	当小程序初始化完成时，会触发 onLaunch（全局只触发一次）
     onLaunch (options) {
-      const rootVM = this.rootVM = initRootVM(this, opt)
+      const rootVM = this.rootVM = initRootVM(this, opt, options.query)
       const { globalData = () => {} } = rootVM.$options
       rootVM.$mount()
       callHook(rootVM, 'onLaunch', options)

--- a/src/platforms/mp/runtime/lifecycle/page.js
+++ b/src/platforms/mp/runtime/lifecycle/page.js
@@ -11,7 +11,7 @@ page.init = function init (opt) {
       [ROOT_DATA_VAR]: {}
     },
     onLoad (options) {
-      const rootVM = this.rootVM = initRootVM(this, opt)
+      const rootVM = this.rootVM = initRootVM(this, opt, options)
 
       callHook(rootVM, 'onLoad', options)
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

我在尝试开发megalo的通用router写法插件时发现了了this.$root.$mp的一些bug:

**1. 支付宝小程序中无法通过 this.$root.$mp.query 获取页面参数**
只有支付宝小程序无法获取到，百度和微信小程序可以成功获取。百度小程序IDE版本号0.24.1
![image](https://user-images.githubusercontent.com/13115559/48596269-40b70280-e993-11e8-80fd-5446bc0734c7.png)


**2. 三种小程序均无法在 App.vue 的生命周期中通过 this.$root.$mp.query 获取首页参数**
![image](https://user-images.githubusercontent.com/13115559/48596338-97bcd780-e993-11e8-8ddc-847b5ae40bad.png)

建议改为从 options 中获取参数
